### PR TITLE
Support clang, use deque in loop.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.7)
 project(P1160 CXX)
 
 set(CMAKE_CXX_STANDARD 17)
+#set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (MSVC)
     add_definitions (
@@ -11,7 +12,7 @@ if (MSVC)
         /MP
     )
 
-add_definitions (
+    add_definitions (
         # "qualifier applied to function type has no meaning; ignored"
         /wd4180
         #  integral constant overflow
@@ -19,7 +20,64 @@ add_definitions (
         # "'function': was declared deprecated" (referring to STL functions)
         /wd4996
     )
+    set(P1160_TRY_CXX_STD_PREFIX "/std:c++")
+else()
+    set(P1160_TRY_CXX_STD_PREFIX "-std=c++")
+endif()
 
+include(CheckCXXSourceRuns)
+
+set(CMAKE_REQUIRED_FLAGS "${CMAKE_CXX_FLAGS} ${P1160_TRY_CXX_STD_PREFIX}${CMAKE_CXX_STANDARD}")
+
+check_cxx_source_runs(
+   "#include <memory_resource>
+    #include <vector>
+    #include <deque>
+    #include <string>
+
+    int main()
+    {
+        typedef std::pmr::vector<int> ivec;
+        typedef std::pmr::deque<int>  idec;
+        typedef std::pmr::string      pmrstring;
+
+        std::pmr::memory_resource *x = std::pmr::get_default_resource();
+        return x == nullptr;
+    }
+   "
+
+  P1160_HAS_CPP17_MEMORY_RESOURCE
+2)
+
+check_cxx_source_runs(
+   "#include <experimental/memory_resource>
+    #include <experimental/vector>
+    #include <experimental/deque>
+    #include <experimental/string>
+
+    int main()
+    {
+        typedef std::experimental::pmr::vector<int> ivec;
+        typedef std::experimental::pmr::deque<int>  idec;
+        typedef std::experimental::pmr::string      pmrstring;
+
+        std::experimental::pmr::memory_resource *x =
+                                std::experimental::pmr::get_default_resource();
+        return x == nullptr;
+    }
+   "
+
+  P1160_HAS_EXPERIMENTAL_MEMORY_RESOURCE
+)
+
+if(P1160_HAS_CPP17_MEMORY_RESOURCE)
+  # nothing to do
+elseif(P1160_HAS_EXPERIMENTAL_MEMORY_RESOURCE)
+  message("INCLUDE_DIRECTORIES = ${INCLUDE_DIRECTORIES}")
+  include_directories( patchpmr )
+  message("INCLUDE_DIRECTORIES = ${INCLUDE_DIRECTORIES}")
+else()
+  message( FATAL_ERROR "No pmr support in compiler, CMake will exit." )
 endif()
 
 get_filename_component(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR} ABSOLUTE)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The repository consists of 5 major parts:
   * pstring -- a series of examples of testing and fixing an imaginary (and quite pathological) string class (executables)
   * monitoring -- an example of test resource monitoring and replacing the default resource with a test resource
   * exception_testing -- an example using the `exception_test_loop`
+  * patchpmr -- hacks to make clang with libc++ and older GNU libraries with experimental support work
 
 Please read the paper to follow the logic.
 

--- a/patchpmr/deque
+++ b/patchpmr/deque
@@ -1,37 +1,22 @@
-#include <supportlib/framer.h>
-#include <supportlib/assert.h>
+// patchpmr/deque                                                     -*-C++-*-
+#ifndef BLOOMBERGLP_PATCHPMR_DEQUE_INCLUDING_EXPERIMENTAL
 
-#include <memory_resource_p1160>
+#ifndef BLOOMBERGLP_PATCHPMR_DEQUE_INCLUDED
+#define BLOOMBERGLP_PATCHPMR_DEQUE_INCLUDED
 
-#include <deque>
-#include <string>
+#define BLOOMBERGLP_PATCHPMR_DEQUE_INCLUDING_EXPERIMENTAL
+#include <experimental/deque>
+#undef BLOOMBERGLP_PATCHPMR_DEQUE_INCLUDING_EXPERIMENTAL
 
-void test(bool verbose)
-{
-    Framer framer{ "Exception Testing", verbose };
+namespace std::pmr {  using experimental::pmr::deque;  }
+#endif
 
-    std::pmr::test_resource tpmr{ "tester", verbose };
-    const char *longstr = "A very very long string that allocates memory";
-
-    std::pmr::exception_test_loop(tpmr,
-                                  [longstr](std::pmr::memory_resource& pmrp) {
-        std::pmr::deque<std::pmr::string> deq{ &pmrp };
-        deq.emplace_back(longstr);
-        deq.emplace_back(longstr);
-
-        ASSERT_EQ(deq.size(), 2);
-    });
-}
-
-int main()
-{
-    test(false);
-
-    test(true);
-}
+#else
+#   include_next <deque>
+#endif
 
 // ----------------------------------------------------------------------------
-// Copyright 2018 Bloomberg Finance L.P.
+// Copyright 2019 Bloomberg Finance L.P.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/patchpmr/memory_resource
+++ b/patchpmr/memory_resource
@@ -1,37 +1,28 @@
-#include <supportlib/framer.h>
-#include <supportlib/assert.h>
+// patchpmr/memory_resource                                            -*-C++-*-
+#ifndef BLOOMBERGLP_PATCHPMR_INCLUDING_STD_HEADERS
 
-#include <memory_resource_p1160>
+#ifndef BLOOMBERGLP_PATCHPMR_MEMORY_RESOURCE_INCLUDED
+#define BLOOMBERGLP_PATCHPMR_MEMORY_RESOURCE_INCLUDED
 
-#include <deque>
-#include <string>
+#define BLOOMBERGLP_PATCHPMR_INCLUDING_STD_HEADERS
+#include <experimental/memory_resource>
+#undef BLOOMBERGLP_PATCHPMR_INCLUDING_STD_HEADERS
 
-void test(bool verbose)
-{
-    Framer framer{ "Exception Testing", verbose };
+namespace std::pmr {
 
-    std::pmr::test_resource tpmr{ "tester", verbose };
-    const char *longstr = "A very very long string that allocates memory";
+using experimental::pmr::memory_resource;
+using experimental::pmr::polymorphic_allocator;
+using experimental::pmr::new_delete_resource;
 
-    std::pmr::exception_test_loop(tpmr,
-                                  [longstr](std::pmr::memory_resource& pmrp) {
-        std::pmr::deque<std::pmr::string> deq{ &pmrp };
-        deq.emplace_back(longstr);
-        deq.emplace_back(longstr);
-
-        ASSERT_EQ(deq.size(), 2);
-    });
 }
+#endif
 
-int main()
-{
-    test(false);
-
-    test(true);
-}
+#else
+#error Recursive inclusion detected.
+#endif
 
 // ----------------------------------------------------------------------------
-// Copyright 2018 Bloomberg Finance L.P.
+// Copyright 2019 Bloomberg Finance L.P.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/patchpmr/string
+++ b/patchpmr/string
@@ -1,37 +1,22 @@
-#include <supportlib/framer.h>
-#include <supportlib/assert.h>
+// patchpmr/string                                                    -*-C++-*-
+#ifndef BLOOMBERGLP_PATCHPMR_INCLUDING_STD_HEADERS
 
-#include <memory_resource_p1160>
+#ifndef BLOOMBERGLP_PATCHPMR_STRING_INCLUDED
+#define BLOOMBERGLP_PATCHPMR_STRING_INCLUDED
 
-#include <deque>
-#include <string>
+#define BLOOMBERGLP_PATCHPMR_INCLUDING_STD_HEADERS
+#include <experimental/string>
+#undef BLOOMBERGLP_PATCHPMR_INCLUDING_STD_HEADERS
 
-void test(bool verbose)
-{
-    Framer framer{ "Exception Testing", verbose };
+namespace std::pmr {  using experimental::pmr::string;  }
+#endif
 
-    std::pmr::test_resource tpmr{ "tester", verbose };
-    const char *longstr = "A very very long string that allocates memory";
-
-    std::pmr::exception_test_loop(tpmr,
-                                  [longstr](std::pmr::memory_resource& pmrp) {
-        std::pmr::deque<std::pmr::string> deq{ &pmrp };
-        deq.emplace_back(longstr);
-        deq.emplace_back(longstr);
-
-        ASSERT_EQ(deq.size(), 2);
-    });
-}
-
-int main()
-{
-    test(false);
-
-    test(true);
-}
+#else
+#   include_next <string>
+#endif
 
 // ----------------------------------------------------------------------------
-// Copyright 2018 Bloomberg Finance L.P.
+// Copyright 2019 Bloomberg Finance L.P.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/patchpmr/vector
+++ b/patchpmr/vector
@@ -1,37 +1,22 @@
-#include <supportlib/framer.h>
-#include <supportlib/assert.h>
+// patchpmr/vector                                                    -*-C++-*-
+#ifndef BLOOMBERGLP_PATCHPMR_INCLUDING_STD_HEADERS
 
-#include <memory_resource_p1160>
+#ifndef BLOOMBERGLP_PATCHPMR_VECTOR_INCLUDED
+#define BLOOMBERGLP_PATCHPMR_VECTOR_INCLUDED
 
-#include <deque>
-#include <string>
+#define BLOOMBERGLP_PATCHPMR_INCLUDING_STD_HEADERS
+#include <experimental/vector>
+#undef BLOOMBERGLP_PATCHPMR_INCLUDING_STD_HEADERS
 
-void test(bool verbose)
-{
-    Framer framer{ "Exception Testing", verbose };
+namespace std::pmr {  using experimental::pmr::vector;  }
+#endif
 
-    std::pmr::test_resource tpmr{ "tester", verbose };
-    const char *longstr = "A very very long string that allocates memory";
-
-    std::pmr::exception_test_loop(tpmr,
-                                  [longstr](std::pmr::memory_resource& pmrp) {
-        std::pmr::deque<std::pmr::string> deq{ &pmrp };
-        deq.emplace_back(longstr);
-        deq.emplace_back(longstr);
-
-        ASSERT_EQ(deq.size(), 2);
-    });
-}
-
-int main()
-{
-    test(false);
-
-    test(true);
-}
+#else
+#   include_next <vector>
+#endif
 
 // ----------------------------------------------------------------------------
-// Copyright 2018 Bloomberg Finance L.P.
+// Copyright 2019 Bloomberg Finance L.P.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Every example uses `deque` in the exception loop test.