### PR TITLE
Update link to paper so that it doesn't become stale

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains the source code and build system for an example implementation of a `std::pmr`
 compatible polymorphic memory resource, intended for use in instrumented tests. The paper which describes
 the motivation, operation, and other aspects of this code can be found in the
-[WG21 paper repository](http://wg21.link/p1160r0 "P1160R0").
+[WG21 paper repository](http://wg21.link/p1160 "P1160R0").
 
 # Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains the source code and build system for an example implementation of a `std::pmr`
 compatible polymorphic memory resource, intended for use in instrumented tests. The paper which describes
 the motivation, operation, and other aspects of this code can be found in the
-[WG21 paper repository](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1160r0.pdf "P1160R0").
+[WG21 paper repository](http://wg21.link/p1160r0 "P1160R0").
 
 # Prerequisites
 


### PR DESCRIPTION
The link was to R0 of the paper but the most recent version is R1.  By using the wg21.link redirector, the user will always get the most recent revision.